### PR TITLE
Devel to master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer="Wilmar den Ouden" \
 ARG COMPONENTS="frontend|recorder|http"
 ARG OTHER
 
-ENV VERSION="0.106.5"
+ENV VERSION="0.106.6"
 # Run all make job simultaneously
 ENV MAKEFLAGS=-j
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --no-cache \
         postgresql-dev
 
 # Setup requirements files
-ADD "https://raw.githubusercontent.com/home-assistant/home-assistant/${VERSION}/requirements_all.txt" /tmp
+ADD "https://raw.githubusercontent.com/home-assistant/core/${VERSION}/requirements_all.txt" /tmp
 
 # First filter core requirements from a file by selecting comment header until empty line
 # Prefix all components with component to avoid matching packages containing a component name (yi for example)
@@ -42,7 +42,7 @@ RUN awk -v RS= '/# Home Assistant core/' /tmp/requirements_all.txt > /tmp/requir
       awk -v RS= '$0~ENVIRON["OTHER"]' /tmp/requirements_all.txt >> /tmp/requirements.txt; \
     fi; \
     if [ "${VERSION}" = "dev" ]; then \
-      echo -e "https://github.com/home-assistant/home-assistant/archive/dev.zip\npsycopg2" >> /tmp/requirements.txt; \
+      echo -e "https://github.com/home-assistant/core/archive/dev.zip\npsycopg2" >> /tmp/requirements.txt; \
     else \
       echo -e "homeassistant==${VERSION}\npsycopg2" >> /tmp/requirements.txt; \
     fi;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Home Assistant / HASS in Docker!
 
-[![Build Status](https://cloud.drone.io/api/badges/LANsible/docker-home-assistant/status.svg)](https://cloud.drone.io/LANsible/docker-home-assistant)
+[![pipeline status](https://gitlab.com/lansible1/docker-home-assistant/badges/master/pipeline.svg)](https://gitlab.com/lansible1/docker-home-assistant/-/commits/master)
 [![Docker Pulls](https://img.shields.io/docker/pulls/lansible/home-assistant.svg)](https://hub.docker.com/r/lansible/home-assistant)
 [![Docker Version](https://images.microbadger.com/badges/version/lansible/home-assistant:latest.svg)](https://microbadger.com/images/lansible/home-assistant:latest)
 [![Docker Size/Layers](https://images.microbadger.com/badges/image/lansible/home-assistant:latest.svg)](https://microbadger.com/images/lansible/home-assistant:latest)


### PR DESCRIPTION
* Switch to moved `core` repository due renaming of hass
* Update version to 0.106.6
* Update shield url in README